### PR TITLE
feat: issue templates contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: EthBuilders Slack Channel
+    url: http://bit.ly/NYC-Blockchain-Devs-Join-Slack
+    about: Please ask and answer questions here.


### PR DESCRIPTION
Direct people with questions to the slack channel.

Resolves #21 